### PR TITLE
gcimpl

### DIFF
--- a/module1/src/main/java/net/broscorp/gcimpl/GarbageCollectorImplementation.java
+++ b/module1/src/main/java/net/broscorp/gcimpl/GarbageCollectorImplementation.java
@@ -1,10 +1,9 @@
 package net.broscorp.gcimpl;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
-import java.util.Map;
 
 public class GarbageCollectorImplementation implements GarbageCollector {
 
@@ -12,6 +11,36 @@ public class GarbageCollectorImplementation implements GarbageCollector {
   public List<ApplicationBean> collect(HeapInfo heap, StackInfo stack) {
     Collection<ApplicationBean> beans = heap.getBeans().values();
     Deque<StackInfo.Frame> frames = stack.getStack();
-    return Collections.emptyList();
+    List<ApplicationBean> result = new ArrayList<>();
+
+    for (ApplicationBean bean : beans) {
+      if (!isReachable(frames, bean)) {
+        result.add(bean);
+      }
+    }
+    return result;
+  }
+
+  private boolean isReachable(Deque<StackInfo.Frame> frames, ApplicationBean bean) {
+    for (StackInfo.Frame frame : frames) {
+      List<ApplicationBean> rootBeans = frame.getParameters();
+      if (isReachableUtil(rootBeans, bean)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean isReachableUtil(Collection<ApplicationBean> rootBeans, ApplicationBean bean) {
+    if (rootBeans.contains(bean)) {
+      return true;
+    }
+    for (ApplicationBean beanFromFrame : rootBeans) {
+      Collection<ApplicationBean> childBeans = beanFromFrame.getFieldValues().values();
+      if (isReachableUtil(childBeans, bean)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/module1/src/test/java/net/broscorp/gcimpl/GarbageCollectorImplementationTest.java
+++ b/module1/src/test/java/net/broscorp/gcimpl/GarbageCollectorImplementationTest.java
@@ -8,10 +8,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-@Disabled
 class GarbageCollectorImplementationTest {
 
   private final GarbageCollector gc = new GarbageCollectorImplementation();


### PR DESCRIPTION
Достижимость обьекта.
При сборке мусора обьекты можно поделить на две групы: достижимые и не достижимые. Существует цепочка ссылок, начиная с локальной переменной области или static переменной, с помощью которой какой-то код может быть доступен для объекта. Если по этой цепочке нельзя найти обькт значит он не доступен и будет удален. Даже если у нас есть несколько обьектов которые имеют ссылки друг на друга но их невозможно достигнуть вышеуказаной цепочкой ссылок то все обекты будут удалены.
Куча.
Область памяти где хранятся сами обьекты.
Стек.
Область памяти где хранятся примитивы и ссылки.
Для программы выделятся одна общая куча (тоисть обьекты в ней доступны в любом месте), а стек выделяется по одному на поток.

