### PR TITLE
gcimpl

### DIFF
--- a/module1/src/main/java/net/broscorp/gcimpl/GarbageCollectorImplementation.java
+++ b/module1/src/main/java/net/broscorp/gcimpl/GarbageCollectorImplementation.java
@@ -1,10 +1,12 @@
 package net.broscorp.gcimpl;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class GarbageCollectorImplementation implements GarbageCollector {
 
@@ -12,6 +14,46 @@ public class GarbageCollectorImplementation implements GarbageCollector {
   public List<ApplicationBean> collect(HeapInfo heap, StackInfo stack) {
     Collection<ApplicationBean> beans = heap.getBeans().values();
     Deque<StackInfo.Frame> frames = stack.getStack();
-    return Collections.emptyList();
+
+    ArrayList<ApplicationBean> alive = new ArrayList<>();
+    List<ApplicationBean> garbage = new ArrayList<>();
+    for (ApplicationBean a : beans) {
+      int ptrs = 0;
+      for (ApplicationBean d : beans) {
+        if (a == d) {
+          ptrs++;
+        }
+      }
+      for (StackInfo.Frame b : frames) {
+        for (ApplicationBean c : b.getParameters()) {
+          if (a == c) {
+            ptrs++;
+            alive.addAll(getChildren(a));
+          }
+        }
+      }
+      if (ptrs < 2) {
+        garbage.addAll(getChildren(a));
+        garbage = garbage.stream().distinct().collect(Collectors.toList());
+      }
+    }
+
+    garbage.removeAll(alive);
+
+    return garbage;
+  }
+
+  private List<ApplicationBean> getChildren(ApplicationBean bean) {
+    List<ApplicationBean> garbage = new ArrayList<>();
+    garbage.add(bean);
+    bean.getFieldValues()
+        .forEach(
+            (key, value) -> {
+              if (value != bean && !(value.getFieldValues().containsValue(bean))) {
+                garbage.addAll(getChildren(value));
+              }
+            });
+
+    return garbage;
   }
 }

--- a/module1/src/test/java/net/broscorp/gcimpl/GarbageCollectorImplementationTest.java
+++ b/module1/src/test/java/net/broscorp/gcimpl/GarbageCollectorImplementationTest.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-@Disabled
+
 class GarbageCollectorImplementationTest {
 
   private final GarbageCollector gc = new GarbageCollectorImplementation();


### PR DESCRIPTION
Мое понимание работы сборщика:
Каждый объект - экземпляр класса. Все данные об объекте, включая сигнатуры и описание методов, хранят в куче. Куча, насколько я помню, подразделена на разделы. Эти разделы фактически отвечают за отделение объектов-долгожителей от объектов которые пригодятся приложению непродолжительное количество времени. Если объект не вызывался какое-то количество времени после вызова сборщика мусора - он будет флагнут на сборку и собран при следующей сборке.
Стек - это принцип по которому работает память в случае с методами. В начале и в ходе работы приложения методы могут помещаться на вершину стека. Каждый метод вызывается по очереди, по принципу "последний вошел - первым вышел". По мере того как методы выполняются - также уменьшается и счетчик ссылок на каждый конкретный объект. Таким образом, на основании ссылок, а также статусе объекта в куче, JVM может делать вывод о том, необходимо ли отправлять его на сборку мусора при следующем вызове сборщика.
Сам сборщик работает автоматически и, насколько я знаю, в явную его почти никогда не вызывают. Автоматизм осуществляется за счет достижения верхнего предела памяти, который JVM выделяет тому сегменту кучи, который предназначен для новых объектов.

Комментарий по пулл реквесту:
Я осведомлен о том, что мой код фактически завалится как только наткнется на зависимость A->B->C->A. Пока что пытаюсь понять как это обойти. Пока что залью этот PR, мне интересно что будет сказать ревьюверу.